### PR TITLE
Missing Terminator + New Line Fixes

### DIFF
--- a/obfuscator.ps1
+++ b/obfuscator.ps1
@@ -15,6 +15,6 @@ function Base64-Obfuscator {
 		$Var2 = -Join ((65..90) + (97..122) | Get-Random -Count ((1..12) | Get-Random) | %{[char]$_})
 		
 		Write-Output "Encoded Base64 Output`n===========================================================`n"
-		Write-Output "`$$($Var1) = [Text.Encoding]::ASCII.GetString(([Text.Encoding]::ASCII.GetBytes('"$($MixedBase64)"') | Sort-Object { Get-Random -SetSeed $($Seed) })); `$$($Var2) = [Text.Encoding]::ASCII.GetString([Convert]::FromBase64String(`$$($Var1))); IEX `$$($Var2)"
+		Write-Output "`$$($Var1) = [Text.Encoding]::ASCII.GetString(([Text.Encoding]::ASCII.GetBytes(`'$($MixedBase64)') | Sort-Object { Get-Random -SetSeed $($Seed) })); `$$($Var2) = [Text.Encoding]::ASCII.GetString([Convert]::FromBase64String(`$$($Var1))); IEX `$$($Var2)"
 	}
 }

--- a/obfuscator.ps1
+++ b/obfuscator.ps1
@@ -15,6 +15,6 @@ function Base64-Obfuscator {
 		$Var2 = -Join ((65..90) + (97..122) | Get-Random -Count ((1..12) | Get-Random) | %{[char]$_})
 		
 		Write-Output "Encoded Base64 Output`n===========================================================`n"
-		Write-Output "`$$($Var1) = [Text.Encoding]::ASCII.GetString(([Text.Encoding]::ASCII.GetBytes(`"$($MixedBase64)"') | Sort-Object { Get-Random -SetSeed $($Seed) })); `$$($Var2) = [Text.Encoding]::ASCII.GetString([Convert]::FromBase64String(`$$($Var1))); IEX `$$($Var2)"
+		Write-Output "`$$($Var1) = [Text.Encoding]::ASCII.GetString(([Text.Encoding]::ASCII.GetBytes('"$($MixedBase64)"') | Sort-Object { Get-Random -SetSeed $($Seed) })); `$$($Var2) = [Text.Encoding]::ASCII.GetString([Convert]::FromBase64String(`$$($Var1))); IEX `$$($Var2)"
 	}
 }


### PR DESCRIPTION
Me and my friend @V3ded were working on a few things and we came across your Base64-Obfuscator. 

Upon using `Import-Module .\obfuscator.ps1` we got the following error:

```powershell
At C:\Users\kkb\Desktop\obfuscator.ps1:18 char:114
+         Write-Output "`$$($Var1) = [Text.Encoding]::ASCII.GetString(([Text.Encoding]:: ...
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
The string is missing the terminator: '.
At C:\Users\kkb\Desktop\obfuscator.ps1:10 char:10
+     PROCESS {
+             ~
Missing closing '}' in statement block.
At C:\Users\kkb\Desktop\obfuscator.ps1:1 char:28
+ function Base64-Obfuscator {
+                            ~
Missing closing '}' in statement block.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : TerminatorExpectedAtEndOfString
```

It seems you were missing a single `'`. So I simply removed the double quotes and added 1 single quote, because I also noticed that `$MixedBase64` was creating a new line before and after itself, thus breaking the syntax if one was to not manually remove the newlines.

Running `whoami` as Base64 now bodes the following results. Works like a charm! :)

```powershell
PS C:\Users\kkb\Desktop> powershell -exec bypass -nop
Windows PowerShell
Copyright (C) 2013 Microsoft Corporation. All rights reserved.

PS C:\Users\kkb\Desktop> Import-Module .\obfuscator.ps1
PS C:\Users\kkb\Desktop> Base64-Obfuscator -Data "d2hvYW1p"
Encoded Base64 Output
===========================================================

$glyXeBD = [Text.Encoding]::ASCII.GetString(([Text.Encoding]::ASCII.GetBytes('WYp12dvh') | Sort-Object { Get-Random -Se
tSeed 577362974 })); $AaIwWGdbefE = [Text.Encoding]::ASCII.GetString([Convert]::FromBase64String($glyXeBD)); IEX $AaIwW
GdbefE

PS C:\Users\kkb\Desktop> $glyXeBD = [Text.Encoding]::ASCII.GetString(([Text.Encoding]::ASCII.GetBytes('WYp12dvh')
| Sort-Object { Get-Random -SetSeed 577362974 })); $AaIwWGdbefE = [Text.Encoding]::ASCII.GetString([Convert]::FromBase64
String($glyXeBD)); IEX $AaIwWGdbefE
kkb-pc\kkb
```